### PR TITLE
Separating loading and help modals from the reusable modal 

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,12 +32,9 @@
     <div id="reusable-modal" class="modal" tabindex="-1">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content" id='modal-content-wrapper'>
-                <div class="container-fluid d-flex align-items-center">
-                    <img src="assets/Spinner-1s-200px.svg" width="20%" id='loading-spinner'>
-                    <div id="reusable-modal-content" class="modal-body">
-                    </div>
-                    <div class='modal-footer' id='modal-footer'></div>
-                </div>
+                <div id="reusable-modal-header" class="modal-header"></div>
+                <div id="reusable-modal-content" class="modal-body"></div>
+                <div id="reusable-modal-footer" class='modal-footer' id='modal-footer'></div>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -94,6 +94,19 @@
             </div>
         </div>
     </div>
+    <div id="loading-modal" class="modal" data-bs-backdrop="static" tabindex="-1">
+        <!--Modal to signify a loading state. Has a spinning wheel.-->
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content" id='modal-content-wrapper'>
+                <div class="container-fluid d-flex align-items-center">
+                    <img src="assets/Spinner-1s-200px.svg" width="20%" id='loading-spinner'>
+                    <div class="modal-body">
+                        Loading
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
     <nav class="navbar navbar-dark bg-dark mb-3">
         <div class="container-fluid d-flex align-items-center px-3 py-2">
             <a class="navbar-brand">COVID RESOURCES INDIA</a>

--- a/index.html
+++ b/index.html
@@ -9,14 +9,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
     <script src="https://kit.fontawesome.com/1d39151f79.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css" integrity="sha384-wESLQ85D6gbsF459vf1CiZ2+rr+CsxRY0RpiF1tLlQpDnAgg6rwdsUF1+Ics2bni" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf"
+        crossorigin="anonymous"></script>
+    <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css"
+        integrity="sha384-wESLQ85D6gbsF459vf1CiZ2+rr+CsxRY0RpiF1tLlQpDnAgg6rwdsUF1+Ics2bni" crossorigin="anonymous">
 
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400;500;700;800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400;500;700;800&display=swap"
+        rel="stylesheet">
 </head>
 
 <body class='min-vh-100 d-flex flex-column h-100'>
@@ -35,10 +41,64 @@
             </div>
         </div>
     </div>
+    <div id="help-modal" class="modal" tabindex="-1">
+        <!--Modal to show initially helpful information and credits-->
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content" id='modal-content-wrapper'>
+                <div class="modal-header">
+                    Information
+                </div>
+                <div class="modal-body">
+                    <i class="fas fa-exclamation-circle fs-4 mt-1 mb-1"></i>
+                    <div>Welcome to covid.resources.india's official website.</div>
+                    <div>
+                        How to use:
+                        <ol>
+                            <li>Select a state using the dropdown box.</li>
+                            <li>Click one of the resource buttons to view leads for that resource in that state.</li>
+                            <li>Verified resources have a green badge at the bottom, and have been verified by our
+                                volunteers.</li>
+                            <li>Unverified resources have not been verified yet, but still have a chance of working.
+                            </li>
+                        </ol>
+                    </div>
+                    <div>Check out our:
+                        <ul>
+                            <li><a href='https://instagram.com/covid.resources.india'>Instagram page</a></li>
+                            <li><a href='https://linktr.ee/Eccentric.Blue'>LinkTree</a></li>
+                            <li><a href='#'>Twitter page</a></li>
+                            </li>
+                        </ul>
+                    </div>
+                    <div>
+                        <a href='https://github.com/shantaram3013/covid19-resource-site/issues'>Report bugs</a>
+                        to <a href='https://github.com/shantaram3013/covid19-resource-site'>GitHub.</a>
+                    </div>
+                    <div>
+                        This site and the data it displays is collected and maintained by volunteers.
+                        <a href='https://www.instagram.com/covid.resources.india/'>
+                            Click here for information on volunteering.
+                        </a>
+                    </div>
+                </div>
+                <div class='modal-footer'>
+                    <div>
+                        Made with <i class="fas fa-heart"></i> by <a href='https://github.com/dakshsethi'>Daksh
+                            Sethi</a>,
+                        <a href='https://github.com/kinshukdua'>Kinshuk Dua</a>,
+                        <a href='https://github.com/Krishna-Sivakumar'>Krishna Sivakumar</a>,
+                        and <a href='https://github.com/shantaram3013'>Siddharth Singh</a>
+                    </div>
+                    <button class="btn btn-secondary" data-bs-dismiss="modal" aria-label="close">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
     <nav class="navbar navbar-dark bg-dark mb-3">
         <div class="container-fluid d-flex align-items-center px-3 py-2">
             <a class="navbar-brand">COVID RESOURCES INDIA</a>
-            <button class="btn btn-outline-success" type="button" id='info-button'>Help/About</button>
+            <button class="btn btn-outline-success" type="button" id='info-button' data-bs-toggle="modal"
+                data-bs-target="#help-modal">Help/About</button>
         </div>
     </nav>
 
@@ -46,11 +106,13 @@
         <div class="accordion" id="filterAccordion">
             <div class="accordion-item">
                 <h2 class="accordion-header" id="headingOne">
-                    <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                    <button class="accordion-button" type="button" data-bs-toggle="collapse"
+                        data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
                         Filters
                     </button>
                 </h2>
-                <div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne" data-bs-parent="#accordionExample">
+                <div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne"
+                    data-bs-parent="#accordionExample">
                     <div class="accordion-body">
 
                         <div class="row d-flex">

--- a/main.js
+++ b/main.js
@@ -379,12 +379,6 @@ function showLoadingDialog() {
     Modal.show();
 }
 
-
-function showInfoDialog(msg) {
-    setModalContent(msg, `<i class="fas fa-exclamation-circle fs-4 mt-1 mb-1"></i>`, "Information", true);
-    Modal.show();
-}
-
 function showErrorDialog(msg) {
     setModalContent(msg, `<i class="fas fa-exclamation-triangle fs-4 mt-1 mb-1"></i>`, "Error", false);
     Modal.show();
@@ -450,50 +444,13 @@ function beginUI() {
 
     // Rendering code on success
     hideDialog();
-    infoButtonHandler();
+    // Show the help modal
+    new bootstrap.Modal(document.getElementById("help-modal"), {}).show();
     populateStateDropdown();
-}
-
-function infoButtonHandler() {
-    showInfoDialog(`
-        <div>Welcome to covid.resources.india's official website.</div>
-        <div>
-        How to use:
-        <ol>
-        <li>Select a state using the dropdown box.</li>
-        <li>Click one of the resource buttons to view leads for that resource in that state.</li>
-        <li>Verified resources have a green badge at the bottom, and have been verified by our volunteers.</li>
-        <li>Unverified resources have not been verified yet, but still have a chance of working.</li>
-        </ol>
-        </div>
-        <div>Check out our:
-            <ul>
-            <li><a href='https://instagram.com/covid.resources.india'>Instagram page</a></li>
-            <li><a href='https://linktr.ee/Eccentric.Blue'>LinkTree</a></li>
-            <li><a href='#'>Twitter page</a></li></li>
-            </ul>
-        </div>
-        <div>
-            <a href='https://github.com/shantaram3013/covid19-resource-site/issues'>Report bugs</a>
-            to <a href='https://github.com/shantaram3013/covid19-resource-site'>GitHub.</a>
-        </div>
-        <div> This site and the data it displays is collected and maintained by volunteers.
-            <a href='https://www.instagram.com/covid.resources.india/'>
-            Click here for information on volunteering.
-            </a>
-        </div>
-        <div>
-        Made with <i class="fas fa-heart"></i> by <a href='https://github.com/dakshsethi'>Daksh Sethi</a>,
-        <a href='https://github.com/kinshukdua'>Kinshuk Dua</a>,
-        <a href='https://github.com/Krishna-Sivakumar'>Krishna Sivakumar</a>,
-        and <a href='https://github.com/shantaram3013'>Siddharth Singh</a>
-        </div>
-    `)
 }
 
 function init() {
     let resTitle = document.querySelector("label[for='information']");
-    document.querySelector('#info-button').addEventListener('click', infoButtonHandler);
     setElementStyleProp(resTitle, "display", "none");
     // Create a loading modal
     Modal = new bootstrap.Modal(document.getElementById("reusable-modal"), {

--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ const PAPA_OPTIONS = {
 }
 
 let Modal = undefined
+let loadingModal = undefined    // variable declaration for the loading modal
 
 function getSheetID(url) {
     return url.split("/")[5];
@@ -188,7 +189,7 @@ function renderButtons(resources) {
 
             function onResLoadSuccess(data) {
                 renderStateResourceData(data, selectedState, resource);
-                hideDialog();
+                loadingModal.hide();
             }
 
             loadStateResource(selectedState, resource, onResLoadSuccess);
@@ -374,9 +375,7 @@ function renderStateResourceData(list, stateName, resName) {
 }
 
 function showLoadingDialog() {
-    let spinner = `<img src="assets/Spinner-1s-200px.svg" width="20%" id='loading-spinner'>`;
-    setModalContent("Loading...", spinner, null, false);
-    Modal.show();
+    loadingModal.show();
 }
 
 function showErrorDialog(msg) {
@@ -443,9 +442,8 @@ function beginUI() {
     }
 
     // Rendering code on success
-    hideDialog();
-    // Show the help modal
-    new bootstrap.Modal(document.getElementById("help-modal"), {}).show();
+    loadingModal.hide();    // Hide the loading modal
+    new bootstrap.Modal(document.getElementById("help-modal"), {}).show();  // Show the help modal
     populateStateDropdown();
 }
 
@@ -457,6 +455,9 @@ function init() {
         backdrop: "static",
         focus: true,
         keyboard: true
+    });
+    loadingModal = new bootstrap.Modal(document.getElementById("loading-modal"), {
+        backdrop: "static"
     });
     showLoadingDialog();
 

--- a/main.js
+++ b/main.js
@@ -219,8 +219,6 @@ function toggleElementDisplay(selector) {
     }
 }
 
-let cardCount = 0;
-
 function renderCard(obj) {
     if (obj.Verified && obj.Verified.toLocaleLowerCase() === "no") return;
     let container = document.getElementById("information");
@@ -371,7 +369,6 @@ function renderStateResourceData(list, stateName, resName) {
     list.forEach(item => {
         renderCard(item)
     })
-    cardCount = list.length
 }
 
 function showLoadingDialog() {

--- a/main.js
+++ b/main.js
@@ -375,6 +375,7 @@ function renderStateResourceData(list, stateName, resName) {
 }
 
 function showLoadingDialog() {
+    // Shows the loading modal
     loadingModal.show();
 }
 
@@ -383,50 +384,32 @@ function showErrorDialog(msg) {
     Modal.show();
 }
 
-function hideDialog() {
-    setModalContent("", "");
-    Modal.hide();
-}
-
 function setModalContent(content, eltString, header, isDismissable, staticBackdrop) {
-    // Sets the content of the reusable modal
-    document.getElementById("modal-content-wrapper").innerHTML = `
-    ${(function () {
-            if (header) {
-                return `
-            <div class='modal-header' id='modal-header'>
-                ${header}
-            </div>`
-            }
-            return "";
-        })()}
-    <div class="container-fluid d-flex align-items-center flex-column">
-        <div id="reusable-modal-content" class="modal-body">
-        ${eltString}
-        ${content}
-        </div>
-    </div>
-    ${(function () {
-            if (isDismissable) {
-                return `
-            <div class='modal-footer' id='modal-footer'>
-                <button type="button" class="btn btn-secondary" onclick="hideDialog()">Close</button>
-            </div>`
-            }
-            return "";
-        })()}`;
+    /*
+    Sets the content of the reusable modal
+    content:        content of the modal's body
+    eltString:      (don't know what this does yet... Whoever knows add it in)
+    header:         content of the modal's header
+    isDismissable:  renders a close button if the modal is closable
+    staticBackdrop: makes the modal's backdrop static if true
+    */
 
-    if (staticBackdrop)
-        document.getElementById("reusable-modal").setAttribute("data-bs-backdrop", "static");
-    else
-        document.getElementById("reusable-modal").setAttribute("data-bs-backdrop", "");
-}
+    // Checking if the arguments are undefined and setting the contents to empty strings, if so
+    header = header ? header : ""
+    content = content ? content : ""
+    eltString = eltString ? eltString : ""
 
-function SetModalSpinnerDisplay(state) {
-    let propString = "none";
-    if (state) propString = "block";
-    let spinner = document.querySelector('#loading-spinner');
-    setElementStyleProp(spinner, display, propString);
+    // Setting the modal's contents here
+    document.getElementById("reusable-modal-header").innerHTML = header
+    document.getElementById("reusable-modal-content").innerHTML = `${eltString} ${content}`
+    if (isDismissable) {
+        document.getElementById("reusable-modal-footer").innerHTML = `<button class="btn btn-secondary" data-bs-dismiss="modal" aria-label="close">Close</button>`;
+    }
+
+    // Overwriting the old modal object with a new one
+    Modal = new bootstrap.Modal(document.getElementById("reusable-modal"), {
+        static: staticBackdrop ? "static" : ""
+    })
 }
 
 function beginUI() {
@@ -450,15 +433,15 @@ function beginUI() {
 function init() {
     let resTitle = document.querySelector("label[for='information']");
     setElementStyleProp(resTitle, "display", "none");
-    // Create a loading modal
-    Modal = new bootstrap.Modal(document.getElementById("reusable-modal"), {
-        backdrop: "static",
-        focus: true,
-        keyboard: true
-    });
+
+    // Instantiate a reusable modal
+    Modal = new bootstrap.Modal(document.getElementById("reusable-modal"), {});
+
+    // Instantiate a loading modal
     loadingModal = new bootstrap.Modal(document.getElementById("loading-modal"), {
-        backdrop: "static"
+        backdrop: "static"  // Note: setting data-bs-backdrop on the modal div doesn't work
     });
+
     showLoadingDialog();
 
     document.querySelector("#states-dropdown").onchange = onStateDropdownChange;


### PR DESCRIPTION
for #23 
changes (till now):
1. separated help modal into it's own div
2. removed showInfoDialog and the calls to it
3. separated the loading modal from the reusable modal
4. cleaned up setModalContent's code (not as much string templating, yay!)
5. added a little bit of documentation

A few screenshots:
<img width="496" alt="Screen Shot 2021-05-01 at 15 31 02" src="https://user-images.githubusercontent.com/45091035/116779230-b0050c00-aa92-11eb-92c9-76d1cd6929a9.png">
<img width="1224" alt="Screen Shot 2021-05-01 at 15 32 09" src="https://user-images.githubusercontent.com/45091035/116779250-c90dbd00-aa92-11eb-8a90-bd3bfdeb2da4.png">
